### PR TITLE
refactor: extract duplicate parameter encoding logic

### DIFF
--- a/forwardemail/aliases.go
+++ b/forwardemail/aliases.go
@@ -125,29 +125,7 @@ func (c *Client) CreateAlias(ctx context.Context, domain, alias string, paramete
 
 	params := url.Values{}
 	params.Add("name", alias)
-	if parameters.Description != "" {
-		params.Add("description", parameters.Description)
-	}
-
-	for k, v := range map[string]*bool{
-		"has_recipient_verification": parameters.HasRecipientVerification,
-		"is_enabled":                 parameters.IsEnabled,
-	} {
-		if v != nil {
-			params.Add(k, strconv.FormatBool(*v))
-		}
-	}
-
-	for k, v := range map[string]*[]string{
-		"recipients[]": parameters.Recipients,
-		"labels[]":     parameters.Labels,
-	} {
-		if v != nil {
-			for _, vv := range *v {
-				params.Add(k, vv)
-			}
-		}
-	}
+	encodeAliasParams(params, parameters)
 
 	req, err := c.newRequest(ctx, "POST", fmt.Sprintf("/v1/domains/%s/aliases", encodedDomain), strings.NewReader(params.Encode()))
 	if err != nil {
@@ -189,6 +167,29 @@ func (c *Client) UpdateAlias(ctx context.Context, domain, alias string, paramete
 
 	params := url.Values{}
 	params.Add("name", alias)
+	encodeAliasParams(params, parameters)
+
+	req, err := c.newRequest(ctx, "PUT", fmt.Sprintf("/v1/domains/%s/aliases/%s", encodedDomain, encodedAlias), strings.NewReader(params.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for UpdateAlias: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := c.doRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update alias: %w", err)
+	}
+
+	var item Alias
+	if err := json.Unmarshal(res, &item); err != nil {
+		return nil, fmt.Errorf("failed to parse update alias response: %w", err)
+	}
+
+	return &item, nil
+}
+
+func encodeAliasParams(params url.Values, parameters AliasParameters) {
 	if parameters.Description != "" {
 		params.Add("description", parameters.Description)
 	}
@@ -212,25 +213,6 @@ func (c *Client) UpdateAlias(ctx context.Context, domain, alias string, paramete
 			}
 		}
 	}
-
-	req, err := c.newRequest(ctx, "PUT", fmt.Sprintf("/v1/domains/%s/aliases/%s", encodedDomain, encodedAlias), strings.NewReader(params.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request for UpdateAlias: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	res, err := c.doRequest(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to update alias: %w", err)
-	}
-
-	var item Alias
-	if err := json.Unmarshal(res, &item); err != nil {
-		return nil, fmt.Errorf("failed to parse update alias response: %w", err)
-	}
-
-	return &item, nil
 }
 
 // DeleteAlias removes an email alias from the specified domain.

--- a/forwardemail/domains.go
+++ b/forwardemail/domains.go
@@ -119,17 +119,7 @@ func (c *Client) CreateDomain(ctx context.Context, name string, parameters Domai
 	params := url.Values{}
 	params.Add("domain", name)
 
-	for k, v := range map[string]*bool{
-		"has_adult_content_protection": parameters.HasAdultContentProtection,
-		"has_phishing_protection":      parameters.HasPhishingProtection,
-		"has_executable_protection":    parameters.HasExecutableProtection,
-		"has_virus_protection":         parameters.HasVirusProtection,
-		"has_recipient_verification":   parameters.HasRecipientVerification,
-	} {
-		if v != nil {
-			params.Add(k, strconv.FormatBool(*v))
-		}
-	}
+	encodeDomainParams(params, parameters)
 
 	req, err := c.newRequest(ctx, "POST", "/v1/domains", strings.NewReader(params.Encode()))
 	if err != nil {
@@ -168,17 +158,7 @@ func (c *Client) UpdateDomain(ctx context.Context, name string, parameters Domai
 	params := url.Values{}
 	params.Add("domain", name)
 
-	for k, v := range map[string]*bool{
-		"has_adult_content_protection": parameters.HasAdultContentProtection,
-		"has_phishing_protection":      parameters.HasPhishingProtection,
-		"has_executable_protection":    parameters.HasExecutableProtection,
-		"has_virus_protection":         parameters.HasVirusProtection,
-		"has_recipient_verification":   parameters.HasRecipientVerification,
-	} {
-		if v != nil {
-			params.Add(k, strconv.FormatBool(*v))
-		}
-	}
+	encodeDomainParams(params, parameters)
 
 	req, err := c.newRequest(ctx, "PUT", fmt.Sprintf("/v1/domains/%s", encodedName), strings.NewReader(params.Encode()))
 	if err != nil {
@@ -225,4 +205,18 @@ func (c *Client) DeleteDomain(ctx context.Context, name string) error {
 	}
 
 	return nil
+}
+
+func encodeDomainParams(params url.Values, parameters DomainParameters) {
+	for k, v := range map[string]*bool{
+		"has_adult_content_protection": parameters.HasAdultContentProtection,
+		"has_phishing_protection":      parameters.HasPhishingProtection,
+		"has_executable_protection":    parameters.HasExecutableProtection,
+		"has_virus_protection":         parameters.HasVirusProtection,
+		"has_recipient_verification":   parameters.HasRecipientVerification,
+	} {
+		if v != nil {
+			params.Add(k, strconv.FormatBool(*v))
+		}
+	}
 }


### PR DESCRIPTION
## What and Why

This pull request refactors parameter encoding logic for domain and alias management in the ForwardEmail client, improving code reusability and maintainability. The main changes involve extracting repeated code for encoding parameters into dedicated helper functions, and updating the relevant methods to use these helpers.

**Refactoring and Code Reuse:**

* Introduced the `encodeAliasParams` helper function in `forwardemail/aliases.go` to centralize and simplify alias parameter encoding, replacing duplicated logic in both `CreateAlias` and `UpdateAlias`. [[1]](diffhunk://#diff-f8c3fc6fef36d2656812842b39ca340084480df32470fe3a4db26cbde58fe372L128-R128) [[2]](diffhunk://#diff-f8c3fc6fef36d2656812842b39ca340084480df32470fe3a4db26cbde58fe372R170-R192) [[3]](diffhunk://#diff-f8c3fc6fef36d2656812842b39ca340084480df32470fe3a4db26cbde58fe372L215-L233)
* Added the `encodeDomainParams` helper function in `forwardemail/domains.go` to handle domain parameter encoding, removing repeated code from `CreateDomain` and `UpdateDomain`. [[1]](diffhunk://#diff-28d66b8bd2dc3be8c7a617ba8d9e0781c1870bf1947a6d639d010f2677a62adaL122-R122) [[2]](diffhunk://#diff-28d66b8bd2dc3be8c7a617ba8d9e0781c1870bf1947a6d639d010f2677a62adaL171-R161) [[3]](diffhunk://#diff-28d66b8bd2dc3be8c7a617ba8d9e0781c1870bf1947a6d639d010f2677a62adaR209-R222)